### PR TITLE
Fix drawing state when releasing mouse outside canvas

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -357,6 +357,10 @@ document.addEventListener("DOMContentLoaded", function () {
   displayColorHistory();
   exportCanvas();
 
+  // Ensure drawing stops when releasing the mouse outside the canvas
+  document.addEventListener("mouseup", handleMouseUp);
+  document.addEventListener("touchend", handleMouseUp);
+
   function switchTab(event) {
     const tabButton = event.target;
     tabIndex = parseInt(tabButton.getAttribute('data-tab-index'));


### PR DESCRIPTION
## Summary
- stop drawing when mouseup or touchend occurs outside the canvas

## Testing
- `node -e "0"`

------
https://chatgpt.com/codex/tasks/task_e_68497f3c3414832885025f08ad0ab33c